### PR TITLE
Upload model to track md5 hash of previous uploads

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -2,15 +2,19 @@ class Import < ActiveRecord::Base
   mount_uploader :file, FileUploader
 
   validates :file, presence: true
-  validates :md5, presence: true, uniqueness: true
+  validate :file_uniqueness
 
-  before_validation :set_md5
+  after_create :create_upload
 
   private
 
-  def set_md5
-    if file.present? && file_changed?
-      self.md5 = file.md5
+  def create_upload
+    Upload.create(md5: file.md5)
+  end
+
+  def file_uniqueness
+    if Upload.where(md5: file.md5).any?
+      errors[:base] << 'File has already been uploaded'
     end
   end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,0 +1,3 @@
+class Upload < ActiveRecord::Base
+  validates :md5, presence: true, uniqueness: true
+end

--- a/app/views/imports/show.html.haml
+++ b/app/views/imports/show.html.haml
@@ -9,8 +9,4 @@
   = @import.created_at.strftime('%d/%m/%Y at %H:%M:%S')
 
 %p
-  MD5:
-  = @import.md5
-
-%p
   = link_to 'Back', imports_url

--- a/db/migrate/20160727090200_create_imports.rb
+++ b/db/migrate/20160727090200_create_imports.rb
@@ -2,7 +2,6 @@ class CreateImports < ActiveRecord::Migration
   def change
     create_table :imports do |t|
       t.string :file
-      t.string :md5, index: true
       t.boolean :successful, default: false
 
       t.timestamps

--- a/db/migrate/20160803093015_create_uploads.rb
+++ b/db/migrate/20160803093015_create_uploads.rb
@@ -1,0 +1,10 @@
+class CreateUploads < ActiveRecord::Migration
+  def change
+    create_table :uploads do |t|
+      t.string :md5
+
+      t.timestamps null: false
+    end
+    add_index :uploads, :md5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727090200) do
+ActiveRecord::Schema.define(version: 20160803093015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,13 +35,10 @@ ActiveRecord::Schema.define(version: 20160727090200) do
 
   create_table "imports", force: :cascade do |t|
     t.string   "file"
-    t.string   "md5"
     t.boolean  "successful", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  add_index "imports", ["md5"], name: "index_imports_on_md5", using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -104,6 +101,14 @@ ActiveRecord::Schema.define(version: 20160727090200) do
 
   add_index "prisoners", ["noms_id"], name: "index_prisoners_on_noms_id", using: :btree
   add_index "prisoners", ["pnc_number"], name: "index_prisoners_on_pnc_number", using: :btree
+
+  create_table "uploads", force: :cascade do |t|
+    t.string   "md5"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "uploads", ["md5"], name: "index_uploads_on_md5", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -2,26 +2,26 @@ require 'rails_helper'
 
 RSpec.describe Import, type: :model do
   it { should validate_presence_of(:file) }
-  it { should validate_presence_of(:md5) }
-  it { should validate_uniqueness_of(:md5) }
 
   let(:sample_import_1) { fixture_file_upload('files/sample_import_1.csv', 'text/csv') }
   let(:sample_import_2) { fixture_file_upload('files/sample_import_2.csv', 'text/csv') }
 
-  describe 'md5' do
+  describe 'creating a new import' do
     subject { Import.new(file: sample_import_1) }
 
     before { subject.save! }
 
-    it 'should generate and save an md5 hash when creating an import' do
+    it 'should create an Upload record saving the md5 hash when successful' do
       expect(Import.count).to eq(1)
-      expect(Import.first.md5).to_not be_blank
+      expect(Upload.count).to eq(1)
+      expect(Upload.first.md5).to_not be_blank
     end
 
     it 'should not save when same file used to create another import' do
       import = Import.create(file: sample_import_1)
       expect(Import.count).to eq(1)
-      expect(import.errors.messages).to include(md5: ['has already been taken'])
+      expect(Upload.count).to eq(1)
+      expect(import.errors.messages).to include(base: ['File has already been uploaded'])
     end
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Upload, type: :model do
+  it { should validate_presence_of(:md5) }
+  it { should validate_uniqueness_of(:md5) }
+end


### PR DESCRIPTION
MD5 hashes of import files uploaded tracked in Upload model. Imports are validated against upload records for uniqueness.