### PR TITLE
Ditch ENTRYPOINT for CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN bundle exec rake swagger:docs
 
 RUN RAILS_ENV=production bin/rake --trace
 
-ENTRYPOINT ["./run.sh"]
+CMD ["./run.sh"]


### PR DESCRIPTION
Having entrypoint isn't allowing us to run custom commands or bash,
which is sometimes needed when modifying the state of the database.