### PR TITLE
move swagger into static assets

### DIFF
--- a/config/initializers/swagger_docs.rb
+++ b/config/initializers/swagger_docs.rb
@@ -2,9 +2,9 @@
 Swagger::Docs::Config.register_apis({
   "1.0" => {
     :api_extension_type => :json,
-    :api_file_path => "public/",
+    :api_file_path => "public/assets/",
     :clean_directory => false,
-    :base_path => "#{Rails.application.config.force_ssl ? 'https' : 'http'}://#{ENV['HTTP_HOST']}",
+    :base_path => "/assets/",
     :attributes => {
       :info => {
         "title" => "Prisoners API",

--- a/public/swagger-ui/index.html
+++ b/public/swagger-ui/index.html
@@ -35,7 +35,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "http://localhost:3000/api-docs.json";
+        url = "/assets/api-docs.json";
       }
 
       // Pre load translate...


### PR DESCRIPTION
Use relative URLs and put swagger into /assets/.

This appears to work fine on local dev environment, so it might be
interesting to test and see if it works on a real env. This eliminates
the need of using HTTP_HOST variable.

@cesidio could you please review this and shall we test it ?